### PR TITLE
Remove Required Secret

### DIFF
--- a/.github/workflows/build-dotnet-library.yml
+++ b/.github/workflows/build-dotnet-library.yml
@@ -17,10 +17,6 @@ on:
         type: number
         required: false
         default: 80
-    secrets:
-      GITHUB_TOKEN_PACKAGES:
-        description: 'Token with write:packages permission for pushing NuGet packages'
-        required: true
 
 jobs:
   build-and-test:


### PR DESCRIPTION
# Description
- Callers will use `secrets: inherit` so we don't need to add them as required passthrough.
- Remove the requirement